### PR TITLE
Add license to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,9 @@ Helpful debug commands:
 readelf -p .sshash_str basic-test  # human-readable string dump of .sshash_str section of ELF file basic-test
 readelf -x .sshash_str basic-test  # hex dump of same section
 ```
+
+## License
+
+SPDX-License-Identifier: BSD-3-Clause
+
+See [LICENSE](LICENSE) for the full license text.


### PR DESCRIPTION
This will add a license section to the README.md file. This is to fix #1.